### PR TITLE
chore(docker): allow entrypoint to read secrets then drop to non-root

### DIFF
--- a/docs/docker/docker-entrypoint.sh
+++ b/docs/docker/docker-entrypoint.sh
@@ -24,4 +24,23 @@ export_if_file "AZURE_CLIENT_SECRET"
 export_if_file "AZURE_TENANT_ID"
 export_if_file "DB_PASSWORD"
 
-exec "$@"
+# Drop privileges and exec the final command as the non-root app user
+# Prefer gosu for proper signal forwarding and exec semantics. Fall back to
+# runuser or su if gosu is not available. If no helper is present, exec as-is.
+drop_priv_and_exec() {
+  target_user="appuser"
+  if command -v gosu >/dev/null 2>&1; then
+    exec gosu "$target_user" "$@"
+  elif command -v runuser >/dev/null 2>&1; then
+    # runuser preserves environment and runs command as target user
+    exec runuser -u "$target_user" -- "$@"
+  elif command -v su >/dev/null 2>&1; then
+    # su -c runs command as target user via a shell
+    exec su -s /bin/sh -c "\"$*\"" "$target_user"
+  else
+    # last resort: just exec the command (may run as root)
+    exec "$@"
+  fi
+}
+
+drop_priv_and_exec "$@"

--- a/src/BloodThinnerTracker.Api/Dockerfile
+++ b/src/BloodThinnerTracker.Api/Dockerfile
@@ -13,9 +13,9 @@ RUN dotnet publish src/BloodThinnerTracker.Api/BloodThinnerTracker.Api.csproj -c
 # Stage 2 - Runtime with Noble Chiseled + Azure CLI
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 
-# Install Azure CLI via official script
+# Install Azure CLI via official script and a small privilege-drop helper (gosu)
 USER root
-RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
+RUN apt-get update && apt-get install -y curl ca-certificates gnupg gosu \
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
     && apt-get clean
 
@@ -30,14 +30,13 @@ WORKDIR /app
 # Copy published output
 COPY --from=build /app /app
 
-# Copy entrypoint script into image and make executable
+# Copy entrypoint script into image and make executable (keep owned by root so
+# it can read secret files at startup). The entrypoint will drop privileges.
 COPY docs/docker/docker-entrypoint.sh /docker-entrypoint.sh
-RUN chown appuser:appgroup /docker-entrypoint.sh && chmod 0555 /docker-entrypoint.sh
+RUN chmod 0555 /docker-entrypoint.sh
 
 # Set permissions
 RUN chown -R appuser:appgroup /app
-
-USER appuser
 
 # API listens on port 5234 by default
 ENV ASPNETCORE_URLS=http://+:5234

--- a/src/BloodThinnerTracker.Web/Dockerfile
+++ b/src/BloodThinnerTracker.Web/Dockerfile
@@ -15,9 +15,9 @@ RUN dotnet publish src/BloodThinnerTracker.Web/BloodThinnerTracker.Web.csproj -c
 # Stage 2 - Runtime with Noble Chiseled + Azure CLI
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 
-# Install Azure CLI via official script
+# Install Azure CLI via official script and a small privilege-drop helper (gosu)
 USER root
-RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
+RUN apt-get update && apt-get install -y curl ca-certificates gnupg gosu \
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
     && apt-get clean
 
@@ -36,11 +36,10 @@ COPY --from=build /app /app
 COPY docs/docker/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod 0555 /docker-entrypoint.sh
 
-# Set permissions
+# Set permissions (keep files owned by appuser, but leave runtime user as root
+# so the entrypoint can read root-owned secret files). The entrypoint will
+# drop privileges to `appuser` before exec'ing the app.
 RUN chown -R appuser:appgroup /app
-
-# Ensure the non-root user owns the app files
-USER appuser
 
 # Configure listening port used by the app
 ENV ASPNETCORE_URLS=http://+:5235


### PR DESCRIPTION
Install gosu, ensure entrypoint runs as root so it can read root-owned secrets and then drop privileges to appuser before exec'ing the app. This fixes secret access when secrets are mounted root:root (0400).