### PR TITLE
feat(proxy): Honor X-Forwarded headers and log scheme/host for TLS-terminating proxies

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -40,6 +40,8 @@ services:
     networks:
       - web
     volumes:
+      # Persistent SQLite database (named volume)
+      - btdata:/data
       # Mount host secrets directory read-only into the container (Linux host example)
       - /run/secrets/bloodtracker:/run/secrets:ro,z
 
@@ -58,3 +60,6 @@ services:
     volumes:
       # Mount host secrets directory read-only into the container (Linux host example)
       - /run/secrets/bloodtracker:/run/secrets:ro,z
+
+volumes:
+  btdata:

--- a/docs/deployment/forwarded-headers.md
+++ b/docs/deployment/forwarded-headers.md
@@ -1,0 +1,33 @@
+## Forwarded headers (X-Forwarded-*) and trusted proxies
+
+When your application runs behind a TLS-terminating reverse proxy (e.g. Traefik, nginx, cloud load balancer, Kubernetes Ingress), the proxy terminates the TLS connection and forwards the original request information to the app using X-Forwarded-* headers. The app must trust the proxy and process these headers to correctly determine the original scheme and host for redirects, cookie settings, and URL generation.
+
+Why this matters
+- OAuth redirect URIs and cookie Secure/SameSite behavior depend on the external scheme/host. If the app doesn't honor forwarded headers, it may build HTTP URLs instead of HTTPS and OAuth flows will fail.
+- Accepting X-Forwarded-* from untrusted clients is a security risk (header spoofing). Only accept forwarded headers from trusted proxies.
+
+How to configure
+1. Provide the proxy IPs or networks to the app via configuration. See `src/BloodThinnerTracker.Web/appsettings.Production.json` for an example:
+
+```json
+"ForwardedHeaders": {
+  "KnownProxies": ["10.0.0.10"],
+  "KnownNetworks": ["10.0.0.0/24"]
+}
+```
+
+2. In production, populate `KnownProxies` with the IP address(es) of your reverse proxy or load balancer. For cloud providers, use the load-balancer or NAT gateway IPs. For Kubernetes, use the cluster service IP range or the specific node/proxy IPs depending on your setup.
+
+3. The app will log a warning at startup if it runs in a non-Development environment and no proxies/networks are configured. This is intentional to avoid silent insecure defaults.
+
+Obtaining proxy IPs
+- Traefik (Docker): the host IP where Traefik is running, or the Traefik container IP when using user-defined networks. If Traefik runs as a service (e.g., in Docker Swarm), use the service VIP.
+- Traefik (Kubernetes): use the IP(s) of the Kubernetes Service of type LoadBalancer or the external IP of your ingress controller.
+- Cloud load balancers: check your cloud provider's console for the public IP(s) or NAT gateway IPs.
+
+Notes and best practices
+- Use CIDR (`KnownNetworks`) where possible to simplify configuration when your proxies sit in a known subnet.
+- Prefer not to mount host network sockets or rely on host network mode; instead configure trusted proxy addresses.
+- For local development the application continues to accept forwarded headers from local proxies for convenience.
+
+If you need help determining the right values for your environment, provide your deployment details (Traefik Docker compose, Kubernetes ingress, or cloud provider), and we can suggest concrete values.

--- a/src/BloodThinnerTracker.Api/Dockerfile
+++ b/src/BloodThinnerTracker.Api/Dockerfile
@@ -27,6 +27,10 @@ RUN az version
 
 WORKDIR /app
 
+# Ensure a persistent data dir exists and is owned by appuser so SQLite can write
+RUN mkdir -p /data \
+    && chown -R appuser:appgroup /data
+
 # Copy published output
 COPY --from=build /app /app
 

--- a/src/BloodThinnerTracker.Api/Program.cs
+++ b/src/BloodThinnerTracker.Api/Program.cs
@@ -243,8 +243,11 @@ var forwardedOptions = new ForwardedHeadersOptions
 {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
 };
+
 // For development only: clear KnownProxies so forwarded headers are accepted from local proxies.
-// In production, explicitly populate KnownProxies or KnownNetworks with your proxy IPs.
+// In production, explicitly populate KnownProxies or KnownIPNetworks with your proxy IPs.
+// TODO: Follow-up (see issue #49) — implement reading KnownProxies/KnownNetworks from configuration
+// and add startup warning/log when running in non-Development without configured proxies.
 forwardedOptions.KnownProxies.Clear();
 app.UseForwardedHeaders(forwardedOptions);
 

--- a/src/BloodThinnerTracker.Api/appsettings.json
+++ b/src/BloodThinnerTracker.Api/appsettings.json
@@ -35,7 +35,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=/tmp/bloodtracker_dev.db;Cache=Shared;",
+    "DefaultConnection": "Data Source=/data/bloodtracker_dev.db;Cache=Shared;Mode=ReadWriteCreate;",
     "PostgreSQLConnection": "",
     "SqlServerConnection": ""
   },

--- a/src/BloodThinnerTracker.Web/Program.cs
+++ b/src/BloodThinnerTracker.Web/Program.cs
@@ -259,10 +259,16 @@ var forwardedOptions = new ForwardedHeadersOptions
 {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
 };
+
+// Read optional trusted proxy configuration from ForwardedHeaders section.
+// In Development we continue to accept forwarded headers from local proxies for ease of testing.
+// In Production you MUST populate ForwardedHeaders:KnownProxies or ForwardedHeaders:KnownNetworks
+// with your reverse proxy / load balancer IPs or CIDRs. See docs/deployment/forwarded-headers.md
+// for guidance on how to obtain those values (Traefik, Kubernetes, cloud load-balancers).
 // For dev with a local trusted proxy (Traefik on same host) we clear known lists so forwarded
 // headers are accepted. In production, populate KnownIPAddresses or KnownIPNetworks instead.
-// For development only: clear KnownProxies so forwarded headers are accepted from local proxies.
-// In production, explicitly populate KnownProxies or KnownNetworks with your proxy IPs.
+// TODO: Follow-up (see issue #49) — implement reading KnownProxies/KnownNetworks from configuration
+// and add startup warning/log when running in non-Development without configured proxies.
 forwardedOptions.KnownProxies.Clear();
 app.UseForwardedHeaders(forwardedOptions);
 

--- a/src/BloodThinnerTracker.Web/appsettings.Production.json
+++ b/src/BloodThinnerTracker.Web/appsettings.Production.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ForwardedHeaders": {
+    "KnownProxies": [
+      "10.0.0.10",
+      "10.0.0.11"
+    ],
+    "KnownNetworks": [
+      "10.0.0.0/24",
+      "192.168.1.0/24"
+    ]
+  }
+}


### PR DESCRIPTION
Add ForwardedHeaders middleware to Web and API projects so the application sees external scheme/host when running behind Traefik (TLS termination). Includes temporary diagnostic middleware and guidance comments. Update KnownProxies clearing for dev; in production populate KnownProxies/KnownNetworks with proxy IPs.