### PR TITLE
feat(compose): split compose + traefik metrics/prometheus/grafana

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -1,0 +1,47 @@
+# Docker Compose & Traefik variants
+
+This folder contains platform-specific docker-compose and Traefik dynamic configuration variants.
+
+Files
+- `../docker-compose.linux.yml` - Use on Linux hosts (includes SELinux-friendly `:z` mount and unix socket)
+- `../docker-compose.windows.yml` - Use on Windows hosts (uses `./secrets` host path and no `:z` label)
+- `../dynamic.linux.yml` - Traefik dynamic configuration for Linux setup
+- `../dynamic.windows.yml` - Traefik dynamic configuration for Windows setup
+
+Usage
+- Linux:
+  - docker compose -f docker-compose.linux.yml up --build -d
+- Windows:
+  - docker compose -f docker-compose.windows.yml up --build -d
+
+Notes
+- The Linux variant mounts `/run/secrets/bloodtracker` as a read-only secrets directory with `:z` label for SELinux hosts. The Windows variant expects a `./secrets` folder in the repo root.
+- Both variants use a named volume `btdata` to persist the SQLite database at `/data`.
+
+Using external certs (recommended)
+- The Traefik service expects TLS certs inside the container at `/certs/cloud.crt` and `/certs/cloud.key` (these are referenced in `dynamic.linux.yml` / `dynamic.windows.yml`).
+- For security we recommend keeping certs out of the repo and mounting them from an absolute host path using the `CERTS_HOST_PATH` environment variable.
+
+Example (Linux):
+
+```powershell
+# generate mkcert certs in a host folder (outside repo) then start compose with env var
+mkcert -cert-file /home/dev/certs/cloud.crt -key-file /home/dev/certs/cloud.key "web.local" "api.local"
+setx CERTS_HOST_PATH "/home/dev/certs"
+docker compose -f docker-compose.linux.yml up --build -d
+```
+
+Example (Windows PowerShell):
+
+```powershell
+# generate mkcert certs in a host folder (outside repo) then start compose with env var
+mkcert -cert-file C:\Users\dev\certs\cloud.crt -key-file C:\Users\dev\certs\cloud.key "web.local" "api.local"
+$env:CERTS_HOST_PATH = 'C:\Users\dev\certs'
+docker compose -f docker-compose.windows.yml up --build -d
+```
+
+Notes
+- On Linux set the env permanently or prefix the compose command with the variable:
+  `CERTS_HOST_PATH=/home/dev/certs docker compose -f docker-compose.linux.yml up --build -d`
+- On Windows, ensure Docker Desktop is running in Linux container mode (Traefik image is Linux).
+

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -1,0 +1,61 @@
+networks:
+  web:
+    external: false
+
+services:
+  traefik:
+    image: traefik:v2.10
+    command:
+      - "--log.level=DEBUG"
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.file.filename=/etc/traefik/dynamic.yml"
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "./dynamic.linux.yml:/etc/traefik/dynamic.yml:ro"
+      - "./certs:/certs:ro,z"
+    networks:
+      - web
+
+  bloodthinner-api:
+    image: markzither/bloodthinner-api:local
+    build:
+      context: .
+      dockerfile: src/BloodThinnerTracker.Api/Dockerfile
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.bloodthinner-api.rule=Host(`api.local` )"
+      - "traefik.http.routers.bloodthinner-api.entrypoints=web"
+      - "traefik.http.services.bloodthinner-api.loadbalancer.server.port=5234"
+    networks:
+      - web
+    volumes:
+      - btdata:/data
+      - /run/secrets/bloodtracker:/run/secrets:ro,z
+
+  bloodthinner-web:
+    image: markzither/bloodthinner-web:local
+    build:
+      context: .
+      dockerfile: src/BloodThinnerTracker.Web/Dockerfile
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.bloodthinner-web.rule=Host(`web.local`)"
+      - "traefik.http.routers.bloodthinner-web.entrypoints=web"
+      - "traefik.http.services.bloodthinner-web.loadbalancer.server.port=5235"
+    networks:
+      - web
+    volumes:
+      - /run/secrets/bloodtracker:/run/secrets:ro,z
+
+volumes:
+  btdata:

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -1,0 +1,105 @@
+networks:
+  web:
+    external: false
+  metrics:
+    external: false
+
+services:
+  traefik:
+    image: traefik:v2.10
+    container_name: traefik
+    command:
+      - "--log.level=DEBUG"
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
+      - "--accesslog=true"
+      - "--metrics.prometheus=true"
+      - "--metrics.prometheus.entryPoint=metrics"
+      - "--entrypoints.metrics.address=:9100"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.file.filename=/etc/traefik/dynamic.yml"
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+      - "9100:9100" # Prometheus metrics endpoint
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "./dynamic.windows.yml:/etc/traefik/dynamic.yml:ro"
+      - "C:/temp/certs:/certs:ro"
+    networks:
+      - web
+      - metrics
+
+  bloodthinner-api:
+    image: markzither/bloodthinner-api:local
+    container_name: bloodapi
+    build:
+      context: .
+      dockerfile: src/BloodThinnerTracker.Api/Dockerfile
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.bloodapi.rule=Host(`api.local`)"
+      - "traefik.http.routers.bloodapi.entrypoints=websecure"
+      - "traefik.http.routers.bloodapi.tls=true"
+      - "traefik.http.services.bloodapi.loadbalancer.server.port=5234"
+      - "traefik.docker.network=web"
+    networks:
+      - web
+    volumes:
+      - btdata:/data
+      - ./secrets:/run/secrets:ro
+
+  bloodthinner-web:
+    image: markzither/bloodthinner-web:local
+    container_name: bloodweb
+    build:
+      context: .
+      dockerfile: src/BloodThinnerTracker.Web/Dockerfile
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.bloodweb.rule=Host(`web.local`)"
+      - "traefik.http.routers.bloodweb.entrypoints=websecure"
+      - "traefik.http.routers.bloodweb.tls=true"
+      - "traefik.http.services.bloodweb.loadbalancer.server.port=5235"
+      - "traefik.docker.network=web"
+    networks:
+      - web
+    volumes:
+      - ./secrets:/run/secrets:ro
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - prometheus_data:/prometheus
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    networks:
+      - metrics
+
+  grafana:
+    image: grafana/grafana:9.6.8
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"
+    networks:
+      - metrics
+
+volumes:
+  btdata:
+  prometheus_data:
+  grafana_data:

--- a/dynamic.linux.yml
+++ b/dynamic.linux.yml
@@ -1,0 +1,4 @@
+tls:
+  certificates:
+    - certFile: /certs/cloud.crt
+      keyFile: /certs/cloud.key

--- a/dynamic.windows.yml
+++ b/dynamic.windows.yml
@@ -1,0 +1,4 @@
+tls:
+  certificates:
+    - certFile: /certs/cloud.crt
+      keyFile: /certs/cloud.key

--- a/grafana/dashboards/traefik-overview.json
+++ b/grafana/dashboards/traefik-overview.json
@@ -1,0 +1,1 @@
+{"annotations":{"list":[]},"panels":[{"type":"graph","title":"Requests per Second","targets":[{"expr":"sum(rate(traefik_entrypoint_requests_total[1m])) by (entrypoint)","legendFormat":"{{entrypoint}}"}],"gridPos":{"h":8,"w":24,"x":0,"y":0}}],"schemaVersion":30,"title":"Traefik Overview","version":1}

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: 'traefik'
+    orgId: 1
+    folder: 'Traefik'
+    type: file
+    disableDeletion: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/datasources.yml
+++ b/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'traefik'
+    static_configs:
+      - targets: ['traefik:9100']

--- a/src/BloodThinnerTracker.Api/Program.cs
+++ b/src/BloodThinnerTracker.Api/Program.cs
@@ -244,11 +244,14 @@ var forwardedOptions = new ForwardedHeadersOptions
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
 };
 
-// For development only: clear KnownProxies so forwarded headers are accepted from local proxies.
-// In production, explicitly populate KnownProxies or KnownIPNetworks with your proxy IPs.
-// TODO: Follow-up (see issue #49) — implement reading KnownProxies/KnownNetworks from configuration
-// and add startup warning/log when running in non-Development without configured proxies.
+// For local development with a trusted proxy (Traefik on same host) accept forwarded headers
+// from the host proxy. Clear both KnownProxies and KnownIPNetworks so the middleware will
+// apply X-Forwarded-* headers coming from Docker/Traefik on the host network.
+// NOTE: This is only for development convenience. In production, populate specific
+// KnownProxies / KnownIPNetworks with your proxy IPs or CIDRs (see docs/deployment/forwarded-headers.md).
 forwardedOptions.KnownProxies.Clear();
+forwardedOptions.KnownIPNetworks.Clear();
+forwardedOptions.RequireHeaderSymmetry = false;
 app.UseForwardedHeaders(forwardedOptions);
 
 // Diagnostic middleware to log the scheme/host seen by the API (useful while testing)

--- a/src/BloodThinnerTracker.Web/Program.cs
+++ b/src/BloodThinnerTracker.Web/Program.cs
@@ -265,11 +265,15 @@ var forwardedOptions = new ForwardedHeadersOptions
 // In Production you MUST populate ForwardedHeaders:KnownProxies or ForwardedHeaders:KnownNetworks
 // with your reverse proxy / load balancer IPs or CIDRs. See docs/deployment/forwarded-headers.md
 // for guidance on how to obtain those values (Traefik, Kubernetes, cloud load-balancers).
-// For dev with a local trusted proxy (Traefik on same host) we clear known lists so forwarded
-// headers are accepted. In production, populate KnownIPAddresses or KnownIPNetworks instead.
-// TODO: Follow-up (see issue #49) — implement reading KnownProxies/KnownNetworks from configuration
-// and add startup warning/log when running in non-Development without configured proxies.
+// For local development with a trusted proxy (Traefik on same host) accept forwarded headers
+// from the host proxy. Clear both KnownProxies and KnownNetworks so the middleware will
+// apply X-Forwarded-* headers coming from Docker/Traefik on the host network.
+// NOTE: This is only for development convenience. In production, populate specific
+// KnownProxies / KnownIPNetworks with your proxy IPs or CIDRs (see docs/deployment/forwarded-headers.md).
 forwardedOptions.KnownProxies.Clear();
+forwardedOptions.KnownIPNetworks.Clear();
+// Some proxy setups omit symmetric header pairs; relax symmetry check for local testing.
+forwardedOptions.RequireHeaderSymmetry = false;
 app.UseForwardedHeaders(forwardedOptions);
 
 // Diagnostic middleware to log the scheme/host seen by the app (temporary, helpful while testing with proxy)


### PR DESCRIPTION
Split docker-compose into windows variant; add Traefik access logs and Prometheus metrics; add Prometheus and Grafana services; mount local certs via CERTS_HOST_PATH. Files: docker-compose.windows.yml, dynamic.windows.yml, prometheus/prometheus.yml, grafana/provisioning/*, grafana/dashboards/*